### PR TITLE
Blind fix for CI failure (out-of-sync prototypes)

### DIFF
--- a/src/process.cpp
+++ b/src/process.cpp
@@ -322,9 +322,11 @@ bool processInjectDLL(const char* _executablePath, const char* _DLLPath, const c
 	return false;
 }
 
-bool processRun(const char* _cmdLine)
+bool processRun(const char* _cmdLine, bool _hideWindow, uint32_t* _exitCode)
 {
 	RTM_UNUSED(_cmdLine);
+	RTM_UNUSED(_hideWindow);
+	RTM_UNUSED(_exitCode);
 	return false;
 }
 


### PR DESCRIPTION
The prototype of processRun is out-of-sync between Windows and Linux builds, and this is causing the CI builds of MTuner to fail at link time.